### PR TITLE
Add SemaphoreCI to list of CI services

### DIFF
--- a/views/ci.pug
+++ b/views/ci.pug
@@ -2,6 +2,8 @@ extends layout
 //----------------------------------- MIXINS --------------------------------//
 mixin codeship-signup
   a.btn.btn-primary.b(rel="nofollow" target="_blank", href="https://codeship.com/") Open Codeship
+mixin semaphore-signup
+  a.btn.btn-primary.b(rel="nofollow" target="_blank", href="https://semaphoreci.com/") Open Semaphore
 mixin circleci-signup
   a.btn.btn-primary.b(rel="nofollow" target="_blank", href="https://circleci.com/") Open CircleCI
 mixin travis-signup
@@ -60,6 +62,17 @@ block content
                           li
                             .li-filler21
                             +codeship-signup
+                      +pricing-card("Semaphore")
+                        ul
+                          li Free for open source projects
+                          li 100 free private jobs/month
+                          li Paid plans starting from #[strong $29]/month <br>
+                          li Educational and plans for non-profits
+                          li Supports GitHub and Bitbucket
+                          li Native Docker support
+                          li
+                            .li-filler21
+                            +semaphore-signup
                       +pricing-card("Travis CI")
                         ul
                           li Free for open source (public) projects on GitHub


### PR DESCRIPTION
Semaphore is used by thousands of developers all around the world and is ranked as #3 hosted CI service according to [the most recent Heroku survey](https://blog.heroku.com/building-tools-for-developers-heroku-ci). Semaphore was already mentioned to be added in [this request](https://github.com/switowski/deploystack/issues/8).